### PR TITLE
Compile to build/ rather than output/

### DIFF
--- a/lib/nanoc/core/interactors/site_loader.rb
+++ b/lib/nanoc/core/interactors/site_loader.rb
@@ -23,7 +23,7 @@ module Nanoc
     # that lacks some options, the default value will be taken from
     # `DEFAULT_CONFIG`.
     DEFAULT_CONFIG = {
-      :output_dir         => 'output',
+      :output_dir         => 'build',
       :data_sources       => [ {} ],
       :index_filenames    => [ 'index.html' ],
       :enable_output_diff => false,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -83,7 +83,7 @@ EOS
     FileUtils.mkdir_p('content')
     FileUtils.mkdir_p('layouts')
     FileUtils.mkdir_p('lib')
-    FileUtils.mkdir_p('output')
+    FileUtils.mkdir_p('build')
 
     if params[:has_layout]
       File.open('layouts/default.html', 'w') do |io|

--- a/test/nanoc/core/compilation/test_compiler.rb
+++ b/test/nanoc/core/compilation/test_compiler.rb
@@ -10,7 +10,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
     in_site do
       compile_site_here
 
-      assert Dir['output/*'].empty?
+      assert Dir['build/*'].empty?
     end
   end
 
@@ -20,9 +20,9 @@ class Nanoc::CompilerTest < Nanoc::TestCase
 
       compile_site_here
 
-      assert_equal [ 'output/index.html' ], Dir['output/*']
-      assert File.file?('output/index.html')
-      assert File.read('output/index.html') == 'o hello'
+      assert_equal [ 'build/index.html' ], Dir['build/*']
+      assert File.file?('build/index.html')
+      assert File.read('build/index.html') == 'o hello'
     end
   end
 
@@ -33,11 +33,11 @@ class Nanoc::CompilerTest < Nanoc::TestCase
 
       compile_site_here
 
-      assert Dir['output/*'].size == 2
-      assert File.file?('output/foo/index.html')
-      assert File.file?('output/bar/index.html')
-      assert File.read('output/foo/index.html') == 'o hai'
-      assert File.read('output/bar/index.html') == 'o bai'
+      assert Dir['build/*'].size == 2
+      assert File.file?('build/foo/index.html')
+      assert File.file?('build/bar/index.html')
+      assert File.read('build/foo/index.html') == 'o hai'
+      assert File.read('build/bar/index.html') == 'o bai'
     end
   end
 
@@ -52,11 +52,11 @@ class Nanoc::CompilerTest < Nanoc::TestCase
 
       compile_site_here
 
-      assert Dir['output/*'].size == 2
-      assert File.file?('output/foo/index.html')
-      assert File.file?('output/bar/index.html')
-      assert File.read('output/foo/index.html') == 'manatee!!!'
-      assert File.read('output/bar/index.html') == 'manatee'
+      assert Dir['build/*'].size == 2
+      assert File.file?('build/foo/index.html')
+      assert File.file?('build/bar/index.html')
+      assert File.read('build/foo/index.html') == 'manatee!!!'
+      assert File.read('build/bar/index.html') == 'manatee'
     end
   end
 
@@ -140,7 +140,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
 
       # Check
       assert_equal '[[[<%= @item.compiled_content(:snapshot => :aaa) %>]]]',
-        File.read('output/index.html')
+        File.read('build/index.html')
     end
   end
 
@@ -169,8 +169,8 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       # Check
-      assert_equal '[stuff]', File.read('output/a.html')
-      assert_equal 'stuff', File.read('output/z.html')
+      assert_equal '[stuff]', File.read('build/a.html')
+      assert_equal 'stuff', File.read('build/z.html')
     end
   end
 
@@ -195,7 +195,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       # Check
-      assert_equal 'This is 123.', File.read('output/index.html')
+      assert_equal 'This is 123.', File.read('build/index.html')
     end
   end
 
@@ -222,7 +222,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       # Check
-      assert_equal '<h1>A</h1>', File.read('output/index.html')
+      assert_equal '<h1>A</h1>', File.read('build/index.html')
 
       # Create rules
       File.write('Rules', <<-EOS.gsub(/^ {8}/, ''))
@@ -237,7 +237,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       # Check
-      assert_equal '<h1>B</h1>', File.read('output/index.html')
+      assert_equal '<h1>B</h1>', File.read('build/index.html')
     end
   end
 
@@ -264,7 +264,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       # Check
-      assert_equal '@rep.name = default - @item_rep.name = default', File.read('output/index.html')
+      assert_equal '@rep.name = default - @item_rep.name = default', File.read('build/index.html')
     end
   end
 
@@ -283,7 +283,7 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       compile_site_here
 
       assert_equal Set.new(%w( content/blah.dat )), Set.new(Dir['content/*'])
-      assert_equal Set.new(%w( output/blah.dat )), Set.new(Dir['output/*'])
+      assert_equal Set.new(%w( build/blah.dat )), Set.new(Dir['build/*'])
     end
   end
 
@@ -305,11 +305,11 @@ class Nanoc::CompilerTest < Nanoc::TestCase
   def test_prune_do_not_prune_by_default
     in_site do
       File.write('content/index.html', 'o hello')
-      File.write('output/crap', 'o hello')
+      File.write('build/crap', 'o hello')
 
       compile_site_here
 
-      assert_equal [ 'output/crap', 'output/index.html' ], Dir['output/*'].sort
+      assert_equal [ 'build/crap', 'build/index.html' ], Dir['build/*'].sort
     end
   end
 
@@ -317,11 +317,11 @@ class Nanoc::CompilerTest < Nanoc::TestCase
     in_site do
       File.write('nanoc.yaml', "prune:\n  auto_prune: false")
       File.write('content/index.html', 'o hello')
-      File.write('output/crap', 'o hello')
+      File.write('build/crap', 'o hello')
 
       compile_site_here
 
-      assert_equal [ 'output/crap', 'output/index.html' ], Dir['output/*'].sort
+      assert_equal [ 'build/crap', 'build/index.html' ], Dir['build/*'].sort
     end
   end
 
@@ -329,11 +329,11 @@ class Nanoc::CompilerTest < Nanoc::TestCase
     in_site do
       File.write('nanoc.yaml', "prune:\n  auto_prune: true")
       File.write('content/index.html', 'o hello')
-      File.write('output/crap', 'o hello')
+      File.write('build/crap', 'o hello')
 
       compile_site_here
 
-      assert_equal [ 'output/index.html' ], Dir['output/*'].sort
+      assert_equal [ 'build/index.html' ], Dir['build/*'].sort
     end
   end
 
@@ -389,8 +389,8 @@ class Nanoc::CompilerTest < Nanoc::TestCase
 
       compile_site_here
 
-      assert_equal [ 'output/index.html' ], Dir['output/*'].sort
-      assert_match(/My name is What\?!/, File.read('output/index.html'))
+      assert_equal [ 'build/index.html' ], Dir['build/*'].sort
+      assert_match(/My name is What\?!/, File.read('build/index.html'))
     end
   end
 

--- a/test/nanoc/core/compilation/test_compiler_dsl.rb
+++ b/test/nanoc/core/compilation/test_compiler_dsl.rb
@@ -35,10 +35,10 @@ EOS
       compile_site_here
 
       # Check paths
-      assert File.file?('output/raw.txt')
-      assert File.file?('output/filtered.txt')
-      assert_equal 'A <%= "X" %> B', File.read('output/raw.txt')
-      assert_equal 'A X B',          File.read('output/filtered.txt')
+      assert File.file?('build/raw.txt')
+      assert File.file?('build/filtered.txt')
+      assert_equal 'A <%= "X" %> B', File.read('build/raw.txt')
+      assert_equal 'A X B',          File.read('build/filtered.txt')
     end
   end
 
@@ -73,10 +73,10 @@ EOS
       compiler.run
 
       # Check paths
-      assert File.file?('output/foo.txt')
-      assert File.file?('output/bar.txt')
-      assert_equal 'stuff <%= "goes" %> here', File.read('output/foo.txt')
-      assert_equal 'stuff goes here',          File.read('output/bar.txt')
+      assert File.file?('build/foo.txt')
+      assert File.file?('build/bar.txt')
+      assert_equal 'stuff <%= "goes" %> here', File.read('build/foo.txt')
+      assert_equal 'stuff goes here',          File.read('build/bar.txt')
 
       # Check snapshot
       assert_equal 1, site.items.size

--- a/test/nanoc/core/compilation/test_outdatedness_checker.rb
+++ b/test/nanoc/core/compilation/test_outdatedness_checker.rb
@@ -57,7 +57,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
     end
 
     # Delete old item
-    FileUtils.rm_rf('foo/output/index.html')
+    FileUtils.rm_rf('foo/build/index.html')
 
     # Check
     in_site(:name => 'foo') do

--- a/test/nanoc/core/interactors/test_pruner.rb
+++ b/test/nanoc/core/interactors/test_pruner.rb
@@ -19,9 +19,9 @@ class Nanoc::FilesystemPrunerTest < Nanoc::TestCase
 
   def test_find_compiled_files
     in_site do
-      FileUtils.mkdir_p('output/some/random/directories/here')
-      File.write('output/some/random/file.txt', 'blah')
-      File.write('output/index.html', 'yay')
+      FileUtils.mkdir_p('build/some/random/directories/here')
+      File.write('build/some/random/file.txt', 'blah')
+      File.write('build/index.html', 'yay')
 
       pruner = Nanoc::FilesystemPruner.new(site_here)
       files = pruner.find_compiled_files
@@ -32,23 +32,23 @@ class Nanoc::FilesystemPrunerTest < Nanoc::TestCase
 
   def test_find_present_files_and_dirs
     in_site do
-      FileUtils.mkdir_p('output/some/random/dir')
-      File.write('output/some/random/file.txt', 'blah')
-      File.write('output/index.html', 'yay')
+      FileUtils.mkdir_p('build/some/random/dir')
+      File.write('build/some/random/file.txt', 'blah')
+      File.write('build/index.html', 'yay')
 
       pruner = Nanoc::FilesystemPruner.new(site_here)
       files, dirs = pruner.find_present_files_and_dirs
 
       expected_files = [
-        'output/index.html',
-        'output/some/random/file.txt',
+        'build/index.html',
+        'build/some/random/file.txt',
       ]
 
       expected_dirs = [
-        'output/',
-        'output/some',
-        'output/some/random',
-        'output/some/random/dir',
+        'build/',
+        'build/some',
+        'build/some/random',
+        'build/some/random/dir',
       ]
 
       assert_set_equal files, expected_files
@@ -58,37 +58,37 @@ class Nanoc::FilesystemPrunerTest < Nanoc::TestCase
 
   def test_remove_stray_files_and_dirs
     in_site do
-      FileUtils.mkdir_p('output/some/random/dir')
-      File.write('output/some/random/file.txt', 'blah')
-      File.write('output/index.html', 'yay')
+      FileUtils.mkdir_p('build/some/random/dir')
+      File.write('build/some/random/file.txt', 'blah')
+      File.write('build/index.html', 'yay')
 
-      refute_equal Dir['output/**/*'], []
+      refute_equal Dir['build/**/*'], []
 
       pruner = Nanoc::FilesystemPruner.new(site_here)
       pruner.run
 
-      assert_equal Dir['output/**/*'], []
+      assert_equal Dir['build/**/*'], []
     end
   end
 
   def test_exclude
     in_site do
-      FileUtils.mkdir_p('output/some/random/dir')
-      FileUtils.mkdir_p('output/another/random/dir')
-      File.write('output/some/random/file.txt',    'blah')
-      File.write('output/another/random/file.txt', 'blah')
-      File.write('output/another/some',            'blah')
+      FileUtils.mkdir_p('build/some/random/dir')
+      FileUtils.mkdir_p('build/another/random/dir')
+      File.write('build/some/random/file.txt',    'blah')
+      File.write('build/another/random/file.txt', 'blah')
+      File.write('build/another/some',            'blah')
 
-      assert File.file?('output/some/random/file.txt')
-      assert File.file?('output/another/random/file.txt')
-      assert File.file?('output/another/some')
+      assert File.file?('build/some/random/file.txt')
+      assert File.file?('build/another/random/file.txt')
+      assert File.file?('build/another/some')
 
       pruner = Nanoc::FilesystemPruner.new(site_here, exclude: [ 'some' ])
       pruner.run
 
-      assert File.file?('output/some/random/file.txt')
-      refute File.file?('output/another/random/file.txt')
-      assert File.file?('output/another/some')
+      assert File.file?('build/some/random/file.txt')
+      refute File.file?('build/another/random/file.txt')
+      assert File.file?('build/another/some')
     end
   end
 


### PR DESCRIPTION
There are two issues with the `output/` directory:
- It has a nonstandard name: no other similar system uses a directory named `output/`.
- It has been used in older versions of nanoc as a place to store files that were not part of the compilation process. Such usage has been deprecated meanwhile, and `prune` removes files that are not part of the nanoc compilation process.

Two alternatives:
- `public/` is often used as the a directory containing files to be served through HTTP. Drawbacks of this name: 1) in some systems it is allowed and sometimes even encouraged to put files in there manually, which we want to prevent with nanoc; the name `public/` gives the impression that it is usable in the deprecated way; 2) it is used in the context of a web server, which nanoc is not.
- `build/` is a directory often used by build tools as the directory to write generated files too. The name makes it clear that no files are meant to be put in there that are not part of the compilation process.

After a brief discussion, I opted for changing `output/` to `build/`.

Relatedly, I believe `nanoc compile` should change to `nanoc build` for consistency.

CC @bobthecow
