### PR TITLE
Prune by default

### DIFF
--- a/lib/nanoc/core/interactors/site_loader.rb
+++ b/lib/nanoc/core/interactors/site_loader.rb
@@ -27,7 +27,7 @@ module Nanoc
       :data_sources       => [ {} ],
       :index_filenames    => [ 'index.html' ],
       :enable_output_diff => false,
-      :prune              => { :auto_prune => false, :exclude => [ '.git', '.hg', '.svn', 'CVS' ] }
+      :prune              => { :auto_prune => true, :exclude => [ '.git', '.hg', '.svn', 'CVS' ] }
     }
 
     CONFIG_FILENAME = 'nanoc.yaml'

--- a/test/nanoc/core/compilation/test_compiler.rb
+++ b/test/nanoc/core/compilation/test_compiler.rb
@@ -302,14 +302,14 @@ class Nanoc::CompilerTest < Nanoc::TestCase
     end
   end
 
-  def test_prune_do_not_prune_by_default
+  def test_prune_do_prune_by_default
     in_site do
       File.write('content/index.html', 'o hello')
       File.write('output/crap', 'o hello')
 
       compile_site_here
 
-      assert_equal [ 'output/crap', 'output/index.html' ], Dir['output/*'].sort
+      assert_equal [ 'output/index.html' ], Dir['output/*'].sort
     end
   end
 


### PR DESCRIPTION
I believe nanoc should prune after compiling by default.

@bobthecow You had some concerns about this, but I do not remember exactly what your concerns were (see also [the “Always auto-prune” ticket on Trello](https://trello.com/c/CtKmBVKw/7-always-auto-prune)). Do you recall?
